### PR TITLE
fix: Correct ALLOWED_ORIGIN environment variable handling

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -22,4 +22,5 @@ export const SERVER_PORT = typeof process !== 'undefined' && process.env.PORT ? 
 
 export const SERVER_ENDPOINT = `${ADDRESS}:${SERVER_PORT}`;
 
-export const ALLOWED_ORIGIN = process.env.NODE_ENV === 'production' ? process.env.ALLOWED_ORIGIN : '*';
+export const ALLOWED_ORIGIN =
+  typeof process !== 'undefined' && process.env.NODE_ENV === 'production' ? process.env.ALLOWED_ORIGIN : '*';


### PR DESCRIPTION
- Check if process is defined before accessing NODE_ENV.
- Default to '*' for development, use process.env.ALLOWED_ORIGIN for production